### PR TITLE
Remove bound for setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     scripts=['bin/tq'],
     install_requires=[
         'beautifulsoup4==4.8.1',
-        'setuptools==39.0.1'
+        'setuptools'
         ],
     classifiers=[
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Fixes `AttributeError: 'HTMLParser' object has no attribute 'unescape'`